### PR TITLE
Reorder beta to-do items

### DIFF
--- a/pages/beta.tsx
+++ b/pages/beta.tsx
@@ -41,8 +41,8 @@ const BetaInfo = () => {
       </Paragraph>
 
       <UnorderedList>
-        <ListItem>Fix the meta/social sharing preview for individual works.</ListItem>
         <ListItem>Display artists correctly and consolidate them daily.</ListItem>
+        <ListItem>Fix the meta or social sharing preview for individual works.</ListItem>
         <ListItem>A nicer drag-and-drop interface for editing socials.</ListItem>
         <ListItem>Display individual work galleries by maintaining aspect ratio.</ListItem>
         <ListItem>Make the weeks page more usable.</ListItem>


### PR DESCRIPTION
We need to reorder the beta items to show the correct priority of those items.